### PR TITLE
Added ability to make last-minute modifications to the current environment

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [3.0.4] (2019-05-08)
+- Added optional "transformers" on `EnvironmentIdentifierFilter` which allow last-minute
+modification of the environment currently set, before it is retrievable from `EnvironmentUtil`
+
 ## [3.0.3] (2019-02-20)
 - Add @Prematching to EnvironmentModifierFilter to fix "java.lang.IllegalStateException: Method could be called only in pre-matching request filter."
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## [3.0.4] (2019-05-08)
+## [3.1.0] (2019-05-08)
 - Added optional "transformers" on `EnvironmentIdentifierFilter` which allow last-minute
 modification of the environment currently set, before it is retrievable from `EnvironmentUtil`
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.cvent</groupId>
     <artifactId>pangaea</artifactId>
-    <version>3.0.4-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>pangaea</name>

--- a/src/main/java/com/cvent/pangaea/filter/EnvironmentIdentifierFilter.java
+++ b/src/main/java/com/cvent/pangaea/filter/EnvironmentIdentifierFilter.java
@@ -3,10 +3,16 @@ package com.cvent.pangaea.filter;
 
 import com.cvent.pangaea.MultiEnvAware;
 import com.cvent.pangaea.util.EnvironmentUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
 
 /**
  * @author n.golani
@@ -17,32 +23,55 @@ import javax.ws.rs.container.ContainerResponseFilter;
  *then sets the environment value in ThreadLocal field so that it can be accessed at any layer.
  *
  *This filter will be invoked before sending out response so that ThreadLocal variable is cleaned.
- *Cleaning of threadLocal variable is important as some frameworks create thread-pools 
+ *Cleaning of threadLocal variable is important as some frameworks create thread-pools
  *and same threads will be re-used for different requests and if variable has values from previous
  *requests it will lead to errors.
  */
 public class EnvironmentIdentifierFilter implements ContainerRequestFilter, ContainerResponseFilter {
 
-    
+    private static final Logger LOG = LoggerFactory.getLogger(EnvironmentIdentifierFilter.class);
+
+    private List<Function<String, String>> transformers;
+
+    public EnvironmentIdentifierFilter() {
+        this.transformers = new ArrayList();
+    }
+
+    public EnvironmentIdentifierFilter(List<Function<String, String>> transformers) {
+        this.transformers = transformers;
+    }
+
     @Override
     public void filter(ContainerRequestContext requestContext) {
-        
+
         String environmentInRequest = getEnvParamFromRequest(requestContext);
-        
+
+        String transformedEnv = this.transformers.stream().reduce(
+                environmentInRequest, (curEnv, fn) -> fn.apply(curEnv), (a, b) -> b
+        );
+
+
         if (environmentInRequest != null) {
-            EnvironmentUtil.setEnvironment(environmentInRequest);
+
+            if (!environmentInRequest.equals(transformedEnv)) {
+                LOG.debug(
+                        "Changed environment from %s to %s due to transformers", environmentInRequest, transformedEnv
+                );
+            }
+
+            EnvironmentUtil.setEnvironment(transformedEnv);
         }
     }
 
     private String getEnvParamFromRequest(ContainerRequestContext requestContext) {
-        if (requestContext.getUriInfo().getQueryParameters() != null 
+        if (requestContext.getUriInfo().getQueryParameters() != null
             && !requestContext.getUriInfo().getQueryParameters().isEmpty()
                 && requestContext.getUriInfo().getQueryParameters().containsKey(
                         MultiEnvAware.ENVIRONMENT)) {
             return requestContext.getUriInfo().getQueryParameters()
                     .get(MultiEnvAware.ENVIRONMENT).get(0);
         }
-        
+
         return null;
     }
 

--- a/src/main/java/com/cvent/pangaea/filter/EnvironmentIdentifierFilter.java
+++ b/src/main/java/com/cvent/pangaea/filter/EnvironmentIdentifierFilter.java
@@ -46,12 +46,12 @@ public class EnvironmentIdentifierFilter implements ContainerRequestFilter, Cont
 
         String environmentInRequest = getEnvParamFromRequest(requestContext);
 
-        String transformedEnv = this.transformers.stream().reduce(
-                environmentInRequest, (curEnv, fn) -> fn.apply(curEnv), (a, b) -> b
-        );
-
 
         if (environmentInRequest != null) {
+
+            String transformedEnv = this.transformers.stream().reduce(
+                    environmentInRequest, (curEnv, fn) -> fn.apply(curEnv), (a, b) -> b
+            );
 
             if (!environmentInRequest.equals(transformedEnv)) {
                 LOG.debug(

--- a/src/test/java/com/cvent/pangaea/filters/EnvironmentIdentifierFilterTest.java
+++ b/src/test/java/com/cvent/pangaea/filters/EnvironmentIdentifierFilterTest.java
@@ -13,12 +13,17 @@ import javax.ws.rs.core.UriInfo;
 import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+/**
+ * Unit tests for the EnvironmentIdentifierFilter
+ */
 public class EnvironmentIdentifierFilterTest {
 
     private EnvironmentIdentifierFilter filter;
+    private EnvironmentIdentifierFilter filterToNull;
     private EnvironmentIdentifierFilter filterWithTransformers;
     private ContainerRequestContext mockCtx;
     private UriInfo mockUriInfo;
@@ -40,6 +45,11 @@ public class EnvironmentIdentifierFilterTest {
                         key -> SECOND_TRANSFORMED.equals(key) ? FINAL_TRANSFORMED : key
                 )
         );
+        this.filterToNull = new EnvironmentIdentifierFilter(
+                Arrays.asList(
+                        key -> null
+                )
+        );
 
         mockCtx = mock(ContainerRequestContext.class);
         mockUriInfo = mock(UriInfo.class);
@@ -56,6 +66,15 @@ public class EnvironmentIdentifierFilterTest {
         this.filter.filter(mockCtx);
 
         assertEquals(TEST_ENV, EnvironmentUtil.getEnvironment());
+    }
+
+    @Test
+    public void testTransformersToNull() {
+        mockMap.put(MultiEnvAware.ENVIRONMENT, Arrays.asList(TEST_ENV));
+
+        this.filterToNull.filter(mockCtx);
+
+        assertNull(EnvironmentUtil.getEnvironment());
     }
 
     @Test

--- a/src/test/java/com/cvent/pangaea/filters/EnvironmentIdentifierFilterTest.java
+++ b/src/test/java/com/cvent/pangaea/filters/EnvironmentIdentifierFilterTest.java
@@ -57,6 +57,8 @@ public class EnvironmentIdentifierFilterTest {
 
         when(mockCtx.getUriInfo()).thenReturn(mockUriInfo);
         when(mockUriInfo.getQueryParameters()).thenReturn(mockMap);
+
+        EnvironmentUtil.setEnvironment(null);
     }
 
     @Test
@@ -84,6 +86,13 @@ public class EnvironmentIdentifierFilterTest {
         this.filterWithTransformers.filter(mockCtx);
 
         assertEquals(FINAL_TRANSFORMED, EnvironmentUtil.getEnvironment());
+    }
+
+    @Test
+    public void testTransformersNoEnvSet() {
+        this.filterWithTransformers.filter(mockCtx);
+
+        assertNull(EnvironmentUtil.getEnvironment());
     }
 
     @Test

--- a/src/test/java/com/cvent/pangaea/filters/EnvironmentIdentifierFilterTest.java
+++ b/src/test/java/com/cvent/pangaea/filters/EnvironmentIdentifierFilterTest.java
@@ -25,8 +25,8 @@ public class EnvironmentIdentifierFilterTest {
     private MultivaluedMap<String, String> mockMap;
 
     private static final String INTERMEDIATE_TRANSFORMED = "Intermediate Transformed";
+    private static final String SECOND_TRANSFORMED = "2nd Transformed";
     private static final String FINAL_TRANSFORMED = "FINAL Transformed";
-    private static final String NOT_TRANSFORMED = "Not Transformed";
     private static final String TEST_ENV = "Test";
     private static final String TEST_ENV_2 = "Test2";
 
@@ -35,8 +35,9 @@ public class EnvironmentIdentifierFilterTest {
         this.filter = new EnvironmentIdentifierFilter();
         this.filterWithTransformers = new EnvironmentIdentifierFilter(
                 Arrays.asList(
-                        key -> TEST_ENV.equals(key) ? INTERMEDIATE_TRANSFORMED : NOT_TRANSFORMED,
-                        key -> INTERMEDIATE_TRANSFORMED.equals(key) ? FINAL_TRANSFORMED : NOT_TRANSFORMED
+                        key -> TEST_ENV.equals(key) ? INTERMEDIATE_TRANSFORMED : key,
+                        key -> INTERMEDIATE_TRANSFORMED.equals(key) ? SECOND_TRANSFORMED : key,
+                        key -> SECOND_TRANSFORMED.equals(key) ? FINAL_TRANSFORMED : key
                 )
         );
 

--- a/src/test/java/com/cvent/pangaea/filters/EnvironmentIdentifierFilterTest.java
+++ b/src/test/java/com/cvent/pangaea/filters/EnvironmentIdentifierFilterTest.java
@@ -1,0 +1,77 @@
+package com.cvent.pangaea.filters;
+
+import com.cvent.pangaea.MultiEnvAware;
+import com.cvent.pangaea.filter.EnvironmentIdentifierFilter;
+import com.cvent.pangaea.util.EnvironmentUtil;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriInfo;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class EnvironmentIdentifierFilterTest {
+
+    private EnvironmentIdentifierFilter filter;
+    private EnvironmentIdentifierFilter filterWithTransformers;
+    private ContainerRequestContext mockCtx;
+    private UriInfo mockUriInfo;
+    private MultivaluedMap<String, String> mockMap;
+
+    private static final String INTERMEDIATE_TRANSFORMED = "Intermediate Transformed";
+    private static final String FINAL_TRANSFORMED = "FINAL Transformed";
+    private static final String NOT_TRANSFORMED = "Not Transformed";
+    private static final String TEST_ENV = "Test";
+    private static final String TEST_ENV_2 = "Test2";
+
+    @Before
+    public void init() {
+        this.filter = new EnvironmentIdentifierFilter();
+        this.filterWithTransformers = new EnvironmentIdentifierFilter(
+                Arrays.asList(
+                        key -> TEST_ENV.equals(key) ? INTERMEDIATE_TRANSFORMED : NOT_TRANSFORMED,
+                        key -> INTERMEDIATE_TRANSFORMED.equals(key) ? FINAL_TRANSFORMED : NOT_TRANSFORMED
+                )
+        );
+
+        mockCtx = mock(ContainerRequestContext.class);
+        mockUriInfo = mock(UriInfo.class);
+        mockMap = new MultivaluedHashMap();
+
+        when(mockCtx.getUriInfo()).thenReturn(mockUriInfo);
+        when(mockUriInfo.getQueryParameters()).thenReturn(mockMap);
+    }
+
+    @Test
+    public void testBase() {
+        mockMap.put(MultiEnvAware.ENVIRONMENT, Arrays.asList(TEST_ENV));
+
+        this.filter.filter(mockCtx);
+
+        assertEquals(TEST_ENV, EnvironmentUtil.getEnvironment());
+    }
+
+    @Test
+    public void testTransformers() {
+        mockMap.put(MultiEnvAware.ENVIRONMENT, Arrays.asList(TEST_ENV));
+
+        this.filterWithTransformers.filter(mockCtx);
+
+        assertEquals(FINAL_TRANSFORMED, EnvironmentUtil.getEnvironment());
+    }
+
+    @Test
+    public void testTransformersNoTransform() {
+        mockMap.put(MultiEnvAware.ENVIRONMENT, Arrays.asList(TEST_ENV_2));
+
+        this.filterWithTransformers.filter(mockCtx);
+
+        assertEquals(TEST_ENV_2, EnvironmentUtil.getEnvironment());
+    }
+}


### PR DESCRIPTION
Added an optional constructor parameter called **transformers** which allow modification of the current environment before it is possible to retrieve it from EnvironmentUtil. Our use case for this feature will be to disable the setting of the environment based on the configuration values of our app. We will use it so:

```java
        MyConfig config = getConfig(); // pull configs from some configuration file.
        environment.jersey().register(new EnvironmentIdentifierFilter(
              Arrays.asList(env -> config.isProduction() ? null : env)
        ));
```